### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ DcaPal does not store any user data. But if you are still concerned for your pri
 cd dcapal-backend
 docker compose -f docker-compose.yml -f docker/docker-compose.dev.yml up -d
 ```
+(note: if you're using a Mac with an ARM processor replace in the docker-compose dev file cadvisor's image version with gcr.io/cadvisor/cadvisor:v0.47.1 and set platform: linux/aarch64)
 
 **Run DcaPal backend**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ DcaPal does not store any user data. But if you are still concerned for your pri
 cd dcapal-backend
 docker compose -f docker-compose.yml -f docker/docker-compose.dev.yml up -d
 ```
-(note: if you're using a Mac with an ARM processor replace in the docker-compose dev file cadvisor's image version with gcr.io/cadvisor/cadvisor:v0.47.1 and set platform: linux/aarch64)
+(Note: if you're using a Mac with an ARM processor, you should replace (in the docker-compose dev file) Cadvisor's image version with gcr.io/cadvisor/cadvisor:v0.47.1 and set platform: linux/aarch64)
 
 **Run DcaPal backend**
 


### PR DESCRIPTION
On ARM processors there's the need to use a different version of Cadvisor:

`cadvisor The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested`