### PR TITLE
FE: Fix missing suggested quantities when fractional shares are enabled

### DIFF
--- a/dcapal-frontend/package-lock.json
+++ b/dcapal-frontend/package-lock.json
@@ -60,7 +60,7 @@
     },
     "../dcapal-optimizer-wasm/pkg": {
       "name": "dcapal-optimizer-wasm",
-      "version": "0.0.1"
+      "version": "0.4.0"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",


### PR DESCRIPTION
## Pull request details

<!-- Provide details about your pull request and what it adds, fixes, or changes. -->

Use advanced algorithm even when fractional shares are enabled in order to compute quantities to buy or sell. This effectively dismisses legacy linea-programming solver from the FE. Press F to pay homage.

## Breaking changes

<!-- Describe what features are broken by this pull request and why, if any. -->

Removes support from FE for old linear-programming solver

## Issues fixed

<!-- Enter the issue numbers resolved by this pull request below, if any. -->

1. Closes #138 