### PR TITLE
Refactor `portfolioReducer` store to support multiple portfolios

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,7 +153,7 @@ jobs:
                 - ./config/redis/users.acl:/etc/redis/users.acl
                 - ./data/redis/:/data
               healthcheck:
-                test: redis-cli --raw incr ping
+                test: redis-cli --raw ping
                 interval: 10s
                 timeout: 10s
                 retries: 3

--- a/dcapal-backend/docker-compose.yml
+++ b/dcapal-backend/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./config/redis/users.acl:/etc/redis/users.acl
       - ./data/redis/:/data
     healthcheck:
-      test: redis-cli --raw incr ping
+      test: redis-cli --raw ping
       interval: 10s
       timeout: 10s
       retries: 3

--- a/dcapal-frontend/demo/dcapal-60-40.json
+++ b/dcapal-frontend/demo/dcapal-60-40.json
@@ -1,4 +1,5 @@
 {
+  "name": "60/40 Portfolio",
   "quoteCcy": "eur",
   "assets": [
     {

--- a/dcapal-frontend/demo/dcapal-all-seasons.json
+++ b/dcapal-frontend/demo/dcapal-all-seasons.json
@@ -1,4 +1,5 @@
 {
+  "name": "All-seasons Portfolio",
   "quoteCcy": "eur",
   "assets": [
     {

--- a/dcapal-frontend/demo/dcapal-mrrip.json
+++ b/dcapal-frontend/demo/dcapal-mrrip.json
@@ -1,4 +1,5 @@
 {
+  "name": "Mr. RIP Portfolio",
   "quoteCcy": "eur",
   "assets": [
     {

--- a/dcapal-frontend/package-lock.json
+++ b/dcapal-frontend/package-lock.json
@@ -32,7 +32,6 @@
         "redux-persist": "^6.0.0",
         "redux-persist-expire": "^1.1.1",
         "threads": "^1.7.0",
-        "uuid": "^9.0.1",
         "vanilla-cookieconsent": "^2.9.2"
       },
       "devDependencies": {
@@ -9096,18 +9095,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vanilla-cookieconsent": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-2.9.2.tgz",
@@ -15639,11 +15626,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "vanilla-cookieconsent": {
       "version": "2.9.2",

--- a/dcapal-frontend/package.json
+++ b/dcapal-frontend/package.json
@@ -44,7 +44,6 @@
     "redux-persist": "^6.0.0",
     "redux-persist-expire": "^1.1.1",
     "threads": "^1.7.0",
-    "uuid": "^9.0.1",
     "vanilla-cookieconsent": "^2.9.2"
   },
   "devDependencies": {

--- a/dcapal-frontend/public/locales/en/translation.json
+++ b/dcapal-frontend/public/locales/en/translation.json
@@ -84,7 +84,8 @@
       "fetchData": "Just a sec! Fetching fresh data for your portfolio",
       "importPortfolio": "Import Portfolio",
       "ops": "Oops! This is embarassing",
-      "allocateYourSavings": "Allocate your savings"
+      "allocateYourSavings": "Allocate your savings",
+      "defaultPortfolioName": "Main portfolio"
     },
     "initStep": {
       "newPortfolio": "New portfolio",

--- a/dcapal-frontend/public/locales/en/translation.json
+++ b/dcapal-frontend/public/locales/en/translation.json
@@ -54,7 +54,6 @@
     },
     "portfolioStep": {
       "transactionFees": "Transaction fees",
-      "portfolioAssets": "Portfolio assets",
       "quantity": "Quantity",
       "targetWeight": "Target weight",
       "targetWeights": "Target weights",

--- a/dcapal-frontend/public/locales/it/translation.json
+++ b/dcapal-frontend/public/locales/it/translation.json
@@ -84,7 +84,8 @@
       "fetchData": "Un attimo! Recupero dati freschi per il tuo portafoglio",
       "importPortfolio": "Importa Portafoglio",
       "ops": "Ops! Questo è imbarazzante",
-      "allocateYourSavings": "Alloca i tuoi risparmi"
+      "allocateYourSavings": "Alloca i tuoi risparmi",
+      "defaultPortfolioName": "Portafoglio principale"
     },
     "initStep": {
       "newPortfolio": "Nuovo portafoglio",

--- a/dcapal-frontend/public/locales/it/translation.json
+++ b/dcapal-frontend/public/locales/it/translation.json
@@ -54,7 +54,6 @@
     },
     "portfolioStep": {
       "transactionFees": "Costi di transazione",
-      "portfolioAssets": "Asset in portafoglio",
       "quantity": "Quantità",
       "targetWeight": "Allocazione Target",
       "targetWeights": "Pesi Obiettivo",

--- a/dcapal-frontend/src/app/index.js
+++ b/dcapal-frontend/src/app/index.js
@@ -6,7 +6,6 @@ import { AllocationFlow } from "../components/allocationFlow";
 import { setCurrencies } from "./appSlice";
 import { fetchAssetsDcaPal } from "./providers";
 import { ContainerPage } from "../routes/containerPage";
-import CookieConsent from "../components/core/cookieConsent";
 
 const loadCurrencies = async (dispatch) => {
   const res = await fetchAssetsDcaPal("fiat");

--- a/dcapal-frontend/src/app/store.js
+++ b/dcapal-frontend/src/app/store.js
@@ -1,4 +1,5 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import i18n from "i18next";
 import portfolioReducer, {
   FeeType,
   getDefaultFees,
@@ -16,7 +17,7 @@ import {
   REGISTER,
 } from "redux-persist";
 import createMigrate from "redux-persist/es/createMigrate";
-import { mapValues, uuid } from "../utils";
+import { mapValues } from "../utils";
 import { REFRESH_PRICE_INTERVAL_SEC } from "./config";
 
 const migrations = {
@@ -57,8 +58,8 @@ const migrations = {
   },
   4: (state) => {
     const pfolio = state.pfolio;
-    const id = uuid();
-    const name = "Main portfolio";
+    const id = crypto.randomUUID();
+    const name = i18n.t("importStep.defaultPortfolioName");
 
     const hasPfolio = Object.keys(pfolio?.assets).length > 0;
 

--- a/dcapal-frontend/src/app/store.js
+++ b/dcapal-frontend/src/app/store.js
@@ -3,7 +3,7 @@ import portfolioReducer, {
   FeeType,
   getDefaultFees,
 } from "../components/allocationFlow/portfolioStep/portfolioSlice";
-import appReducer from "./appSlice";
+import appReducer, { Step } from "./appSlice";
 import storage from "redux-persist/lib/storage";
 import {
   persistReducer,
@@ -16,7 +16,7 @@ import {
   REGISTER,
 } from "redux-persist";
 import createMigrate from "redux-persist/es/createMigrate";
-import { mapValues } from "../utils";
+import { mapValues, uuid } from "../utils";
 import { REFRESH_PRICE_INTERVAL_SEC } from "./config";
 
 const migrations = {
@@ -55,11 +55,33 @@ const migrations = {
       },
     };
   },
+  4: (state) => {
+    const pfolio = state.pfolio;
+    const id = uuid();
+    const name = "Main portfolio";
+
+    const hasPfolio = Object.keys(pfolio?.assets).length > 0;
+
+    return {
+      ...state,
+      ...(!hasPfolio && { allocationFlowStep: Step.CCY }),
+      pfolio: {
+        selected: id,
+        pfolios: {
+          [id]: {
+            ...pfolio,
+            id: id,
+            name: name,
+          },
+        },
+      },
+    };
+  },
 };
 
 const rootConfig = {
   key: "root",
-  version: 3,
+  version: 4,
   storage,
   migrate: createMigrate(migrations, { debug: false }),
 };

--- a/dcapal-frontend/src/components/allocationFlow/ccyStep/index.js
+++ b/dcapal-frontend/src/components/allocationFlow/ccyStep/index.js
@@ -2,7 +2,10 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { setAllocationFlowStep, Step } from "../../../app/appSlice";
-import { setQuoteCurrency } from "../portfolioStep/portfolioSlice";
+import {
+  currentPortfolio,
+  setQuoteCurrency,
+} from "../portfolioStep/portfolioSlice";
 import { CcyGroup } from "./ccyGroup";
 import { useTranslation } from "react-i18next";
 
@@ -26,7 +29,7 @@ const sortCcy = (a, b) => {
 };
 
 export const CcyStep = ({ ...props }) => {
-  const portfolioState = useSelector((state) => state.pfolio);
+  const portfolioState = useSelector(currentPortfolio);
   const [selected, setSelected] = useState(portfolioState.quoteCcy ?? "");
   const ccys = useSelector((state) => state.app.currencies);
   const dispatch = useDispatch();

--- a/dcapal-frontend/src/components/allocationFlow/endStep/allocateCard.js
+++ b/dcapal-frontend/src/components/allocationFlow/endStep/allocateCard.js
@@ -4,7 +4,11 @@ import { useSelector } from "react-redux";
 import { MEDIA_SMALL } from "../../../app/config";
 import { UNALLOCATED_CASH } from ".";
 import { roundAmount, roundDecimals } from "../../../utils";
-import { ACLASS, FeeType } from "../portfolioStep/portfolioSlice";
+import {
+  ACLASS,
+  FeeType,
+  currentPortfolio,
+} from "../portfolioStep/portfolioSlice";
 import { useTranslation } from "react-i18next";
 
 const feeAmount = (fees, amount) => {
@@ -44,7 +48,7 @@ export const AllocateCard = ({
   theoAlloc,
 }) => {
   const { t, i18n } = useTranslation();
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
   const isMobile = !useMediaQuery(MEDIA_SMALL);
 
   const amtFmt = {

--- a/dcapal-frontend/src/components/allocationFlow/endStep/index.js
+++ b/dcapal-frontend/src/components/allocationFlow/endStep/index.js
@@ -7,6 +7,7 @@ import { Spinner } from "../../spinner/spinner";
 import {
   ACLASS,
   clearBudget,
+  currentPortfolio,
   feeTypeToString,
   isWholeShares,
 } from "../portfolioStep/portfolioSlice";
@@ -136,10 +137,10 @@ export const EndStep = ({ useTaxEfficient, useWholeShares }) => {
   const dispatch = useDispatch();
 
   const { t } = useTranslation();
-  const budget = useSelector((state) => state.pfolio.budget);
-  const assets = useSelector((state) => state.pfolio.assets);
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
-  const fees = useSelector((state) => state.pfolio.fees);
+  const budget = useSelector((state) => currentPortfolio(state).budget);
+  const assets = useSelector((state) => currentPortfolio(state).assets);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
+  const fees = useSelector((state) => currentPortfolio(state).fees);
 
   const cards = solution ? buildCards(assets, solution, quoteCcy, fees) : [];
 

--- a/dcapal-frontend/src/components/allocationFlow/importStep.js
+++ b/dcapal-frontend/src/components/allocationFlow/importStep.js
@@ -10,14 +10,15 @@ import {
   ACLASS,
   FeeType,
   addAsset,
+  addPortfolio,
   clearPortfolio,
   getDefaultFees,
+  getNewPortfolio,
   parseAClass,
   parseFeeType,
-  setFees,
+  selectPortfolio,
   setFeesAsset,
   setQty,
-  setQuoteCurrency,
   setTargetWeight,
 } from "./portfolioStep/portfolioSlice";
 
@@ -53,8 +54,9 @@ const importPfolio = async (pfolio, validCcys, dispatch) => {
     return false;
   }
 
-  dispatch(clearPortfolio());
-  dispatch(setQuoteCurrency({ quoteCcy: pfolio.quoteCcy }));
+  const imported = getNewPortfolio();
+  imported.name = pfolio.name || "Main portfolio";
+  imported.quoteCcy = pfolio.quoteCcy;
 
   const fees = (() => {
     if (pfolio.fees != null && typeof pfolio.fees === "object") {
@@ -64,12 +66,15 @@ const importPfolio = async (pfolio, validCcys, dispatch) => {
     }
   })();
 
+  imported.fees = fees;
+
   if (!pfolio.assets || !Array.isArray(pfolio.assets)) {
     stopWithError("[ImportStep] Missing 'assets' property");
     return false;
   }
 
-  dispatch(setFees({ fees: fees }));
+  dispatch(addPortfolio({ pfolio: imported }));
+  dispatch(selectPortfolio({ id: imported.id }));
 
   for (const a of pfolio.assets) {
     const price = await getFetcher(a.provider, validCcys)(

--- a/dcapal-frontend/src/components/allocationFlow/importStep.js
+++ b/dcapal-frontend/src/components/allocationFlow/importStep.js
@@ -44,7 +44,7 @@ const parseFees = (fees) => {
   return parsed;
 };
 
-const importPfolio = async (pfolio, validCcys, dispatch) => {
+const importPfolio = async (pfolio, validCcys, dispatch, t) => {
   const stopWithError = (...args) => {
     console.log(args);
   };
@@ -55,18 +55,16 @@ const importPfolio = async (pfolio, validCcys, dispatch) => {
   }
 
   const imported = getNewPortfolio();
-  imported.name = pfolio.name || "Main portfolio";
+  imported.name = pfolio.name || t("importStep.defaultPortfolioName");
   imported.quoteCcy = pfolio.quoteCcy;
 
-  const fees = (() => {
+  imported.fees = (() => {
     if (pfolio.fees != null && typeof pfolio.fees === "object") {
       return parseFees(pfolio.fees) || getDefaultFees(FeeType.ZERO_FEE);
     } else {
       return getDefaultFees(FeeType.ZERO_FEE);
     }
   })();
-
-  imported.fees = fees;
 
   if (!pfolio.assets || !Array.isArray(pfolio.assets)) {
     stopWithError("[ImportStep] Missing 'assets' property");
@@ -141,7 +139,7 @@ export const ImportStep = () => {
 
     const runImport = async () => {
       const [success] = await Promise.all([
-        importPfolio(pfolio, validCcys, dispatch),
+        importPfolio(pfolio, validCcys, dispatch, t),
         timeout(1000),
       ]);
 

--- a/dcapal-frontend/src/components/allocationFlow/investStep.js
+++ b/dcapal-frontend/src/components/allocationFlow/investStep.js
@@ -3,7 +3,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useCollapse } from "react-collapsed";
 import { setAllocationFlowStep, Step } from "../../app/appSlice";
 import { InputNumber, InputNumberType } from "../core/inputNumber";
-import { isWholeShares, setBudget } from "./portfolioStep/portfolioSlice";
+import {
+  currentPortfolio,
+  isWholeShares,
+  setBudget,
+} from "./portfolioStep/portfolioSlice";
 import classNames from "classnames";
 import { Trans, useTranslation } from "react-i18next";
 import { spawn, Thread, Worker } from "threads";
@@ -41,9 +45,11 @@ export const InvestStep = ({
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
-  const totalAmount = useSelector((state) => state.pfolio.totalAmount);
-  const assets = useSelector((state) => state.pfolio.assets);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
+  const totalAmount = useSelector(
+    (state) => currentPortfolio(state).totalAmount
+  );
+  const assets = useSelector((state) => currentPortfolio(state).assets);
   const [solution, setSolution] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/assetCard.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/assetCard.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "@react-hook/media-query";
 
 import { InputNumber, InputNumberType } from "../../core/inputNumber";
-import { isWholeShares, removeAsset } from "./portfolioSlice";
+import { currentPortfolio, isWholeShares, removeAsset } from "./portfolioSlice";
 import { MEDIA_SMALL } from "../../../app/config";
 import { useCollapse } from "react-collapsed";
 import classNames from "classnames";
@@ -22,7 +22,7 @@ export const AssetCard = ({
   ...props
 }) => {
   const { t, i18n } = useTranslation();
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
   const dispatch = useDispatch();
   const isMobile = !useMediaQuery(MEDIA_SMALL);
   const { getCollapseProps, getToggleProps, isExpanded } = useCollapse();

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/index.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/index.js
@@ -10,6 +10,7 @@ import { AssetCard } from "./assetCard";
 import {
   addAsset,
   clearPortfolio,
+  currentPortfolio,
   setPrice,
   setQty,
   setRefreshTime,
@@ -57,10 +58,13 @@ export const PortfolioStep = ({ ...props }) => {
   const [isShowFees, setShowFees] = useState(false);
 
   const { t, i18n } = useTranslation();
-  const assetStore = useSelector((state) => state.pfolio.assets);
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const pfolioName = useSelector((state) => currentPortfolio(state).name);
+  const assetStore = useSelector((state) => currentPortfolio(state).assets);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
   const validCcys = useSelector((state) => state.app.currencies);
-  const lastRefreshTime = useSelector((state) => state.pfolio.lastPriceRefresh);
+  const lastRefreshTime = useSelector(
+    (state) => currentPortfolio(state).lastPriceRefresh
+  );
 
   const isMobile = !useMediaQuery(MEDIA_SMALL);
   const dispatch = useDispatch();
@@ -166,7 +170,7 @@ export const PortfolioStep = ({ ...props }) => {
       )}
       {assets && assets.length > 0 && (
         <div className="w-full flex items-center mb-3 pl-3 font-light text-2xl">
-          {t("portfolioStep.portfolioAssets")}
+          {pfolioName}
         </div>
       )}
       <div className="w-full flex flex-col items-center">

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/index.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/index.js
@@ -170,7 +170,7 @@ export const PortfolioStep = ({ ...props }) => {
       )}
       {assets && assets.length > 0 && (
         <div className="w-full flex items-center mb-3 pl-3 font-light text-2xl">
-          {pfolioName}
+          {pfolioName || t("importStep.defaultPortfolioName")}
         </div>
       )}
       <div className="w-full flex flex-col items-center">

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
@@ -137,12 +137,17 @@ const getPortfolio = (id, pfolios) => {
   return pfolios[id];
 };
 
+const initialState = () => {
+  const pfolio = getNewPortfolio();
+  return {
+    selected: pfolio.id,
+    pfolios: { [pfolio.id]: pfolio },
+  };
+};
+
 export const portfolioSlice = createSlice({
   name: "portfolio",
-  initialState: {
-    selected: null,
-    pfolios: {},
-  },
+  initialState: initialState(),
   reducers: {
     addPortfolio: (state, action) => {
       const { pfolio } = action.payload;

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
@@ -109,9 +109,8 @@ export const getDefaultFees = (type) => {
   }
 };
 
-export const portfolioSlice = createSlice({
-  name: "portfolio",
-  initialState: {
+export const buildNewPortfolio = () => {
+  return {
     assets: {},
     quoteCcy: "eur",
     nextIdx: 0,
@@ -119,7 +118,32 @@ export const portfolioSlice = createSlice({
     budget: 0,
     fees: getDefaultFees(FeeType.ZERO_FEE),
     lastPriceRefresh: Date.now(),
-  },
+  };
+};
+
+/*
+TODO: Refactor portfolio slice
+  - Transform state into object:
+{
+  selected: string,
+  pfolios: Map<uuid, pfolio>,
+}
+  - Transform pfolio and add:
+{
+  uuid: string,
+  name: string
+}
+  - Add reducer to insert new portfolio
+  - Add reducer to select pfolio id
+  - Modify every reducer to lookup pfolio via selected id and return if not existing
+  - Update migrator (generate uuid)
+  - Update exporter to download selected pfolio id
+  - Update importer to add new portfolio 
+*/
+
+export const portfolioSlice = createSlice({
+  name: "portfolio",
+  initialState: buildNewPortfolio(),
   reducers: {
     addAsset: (state, action) => {
       const symbol = action.payload.symbol;

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/portfolioSlice.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { roundPrice, uuid } from "../../../utils";
+import { roundPrice } from "../../../utils";
 
 const updateWeight = (asset, totalAmount) => {
   const qty = asset.qty || 0;
@@ -111,7 +111,7 @@ export const getDefaultFees = (type) => {
 
 export const getNewPortfolio = () => {
   return {
-    id: uuid(),
+    id: crypto.randomUUID(),
     name: "",
     assets: {},
     quoteCcy: "eur",
@@ -222,7 +222,6 @@ export const portfolioSlice = createSlice({
 
       pfolio.totalAmount -= qty * price;
       pfolio.totalAmount += newAmount;
-      pfolio.totalAmount = pfolio.totalAmount;
 
       pfolio.assets = {
         ...pfolio.assets,

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/searchBar.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/searchBar.js
@@ -13,7 +13,7 @@ import {
 } from "../../../app/providers";
 import { DCAPAL_API_SEARCH } from "../../../app/config";
 import { Spinner } from "../../spinner/spinner";
-import { ACLASS } from "./portfolioSlice";
+import { ACLASS, currentPortfolio } from "./portfolioSlice";
 import { useTranslation } from "react-i18next";
 
 let searchId = undefined;
@@ -210,7 +210,7 @@ const SearchHeader = (props) => (
 
 const SearchItemCW = (props) => {
   const { i18n } = useTranslation();
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
 
   const [price, setPrice] = useState(null);
   const cancelTokenSources = { price: useRef(null) };
@@ -294,7 +294,7 @@ const SearchItemCW = (props) => {
 };
 
 const SearchItemYF = (props) => {
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
   const validCcys = useSelector((state) => state.app.currencies);
   const { t, i18n } = useTranslation();
 

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/searchBar.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/searchBar.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
-import { v4 as uuidv4 } from "uuid";
 import { api } from "../../../app/api";
 import Fuse from "fuse.js";
 import { useSelector } from "react-redux";
@@ -83,7 +82,7 @@ export const SearchBar = (props) => {
   const fetchSearchApi = async (text) => {
     if (!text || text.length < 2) return;
 
-    searchId = uuidv4();
+    searchId = crypto.randomUUID();
     const currentSearchId = searchId;
 
     const fromDcaPal = async (type) => {

--- a/dcapal-frontend/src/components/allocationFlow/portfolioStep/transactionFees.js
+++ b/dcapal-frontend/src/components/allocationFlow/portfolioStep/transactionFees.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   FeeType,
+  currentPortfolio,
   setFeeType,
   setFeeTypeAsset,
   setFixedFeeAmount,
@@ -17,21 +18,23 @@ import { Trans, useTranslation } from "react-i18next";
 
 export const TransactionFees = ({ asset }) => {
   const dispatch = useDispatch();
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
   const { t } = useTranslation();
 
   const fees = useSelector((state) => {
-    return asset && asset in state.pfolio.assets
-      ? state.pfolio.assets[asset].fees || state.pfolio.fees
-      : state.pfolio.fees;
+    const pfolio = currentPortfolio(state);
+    return asset && asset in pfolio.assets
+      ? pfolio.assets[asset].fees || pfolio.fees
+      : pfolio.fees;
   });
 
   const feeType = useSelector((state) => {
+    const pfolio = currentPortfolio(state);
     return asset
-      ? asset in state.pfolio.assets && state.pfolio.assets[asset].fees
-        ? state.pfolio.assets[asset].fees.feeStructure.type
+      ? asset in pfolio.assets && pfolio.assets[asset].fees
+        ? pfolio.assets[asset].fees.feeStructure.type
         : null
-      : state.pfolio.fees.feeStructure.type;
+      : pfolio.fees.feeStructure.type;
   });
 
   const maxFeeImpact = fees?.maxFeeImpact || null;

--- a/dcapal-frontend/src/components/exportBtn.js
+++ b/dcapal-frontend/src/components/exportBtn.js
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import { Step } from "../app/appSlice";
 import {
   aclassToString,
+  currentPortfolio,
   feeTypeToString,
 } from "./allocationFlow/portfolioStep/portfolioSlice";
 import { useTranslation } from "react-i18next";
@@ -36,7 +37,12 @@ const exportPfolio = (pfolio) => {
     fees: a.fees != null ? toExportedFees(a.fees) : undefined,
   }));
 
-  const data = { quoteCcy: pfolio.quoteCcy, fees: pfolio.fees, assets: assets };
+  const data = {
+    name: pfolio.name,
+    quoteCcy: pfolio.quoteCcy,
+    fees: pfolio.fees,
+    assets: assets,
+  };
   const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
     JSON.stringify(data, null, 2)
   )}`;
@@ -59,13 +65,15 @@ export const ExportBtn = () => {
 
   const step = useSelector((state) => state.app.allocationFlowStep);
 
-  const assets = useSelector((state) => state.pfolio.assets);
-  const quoteCcy = useSelector((state) => state.pfolio.quoteCcy);
-  const fees = useSelector((state) => state.pfolio.fees);
+  const name = useSelector((state) => currentPortfolio(state.pfolio).name);
+  const assets = useSelector((state) => currentPortfolio(state.pfolio).assets);
+  const quoteCcy = useSelector((state) => currentPortfolio(state).quoteCcy);
+  const fees = useSelector((state) => currentPortfolio(state).fees);
 
   const exportedFees = toExportedFees(fees);
 
   const pfolio = {
+    name: name,
     assets: assets,
     quoteCcy: quoteCcy,
     fees: exportedFees,

--- a/dcapal-frontend/src/index.js
+++ b/dcapal-frontend/src/index.js
@@ -13,7 +13,6 @@ import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import translationEN from "../public/locales/en/translation.json";
 import translationIT from "../public/locales/it/translation.json";
-import CookieConsent from "./components/core/cookieConsent";
 
 i18n
   .use(LanguageDetector)

--- a/dcapal-frontend/src/utils/index.js
+++ b/dcapal-frontend/src/utils/index.js
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
-
 export const timeout = (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
@@ -24,8 +22,4 @@ export const replacer = (key, value) => {
 
 export const mapValues = (obj, func) => {
   return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, func(v)]));
-};
-
-export const uuid = () => {
-  return uuidv4().replaceAll("-", "");
 };

--- a/dcapal-frontend/src/utils/index.js
+++ b/dcapal-frontend/src/utils/index.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 export const timeout = (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
@@ -22,4 +24,8 @@ export const replacer = (key, value) => {
 
 export const mapValues = (obj, func) => {
   return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, func(v)]));
+};
+
+export const uuid = () => {
+  return uuidv4().replaceAll("-", "");
 };

--- a/dcapal-frontend/webpack.common.js
+++ b/dcapal-frontend/webpack.common.js
@@ -5,7 +5,7 @@ const Dotenv = require("dotenv-webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
-module.exports = (env, argv) => {
+module.exports = (_env, argv) => {
   const devMode = argv.mode !== "production";
   console.log("Webpack build mode:", argv.mode);
   console.log("  devMode:", devMode);


### PR DESCRIPTION
## Pull request details

<!-- Provide details about your pull request and what it adds, fixes, or changes. -->

- [x] Transform `portfolioSlice` to allow multiple portfolios
- [x] Modify state consumers to offer same behavior as today

## Breaking changes

<!-- Describe what features are broken by this pull request and why, if any. -->

- No breaking changes. Portfolio importer will be updated to support old and new exported portfolios.

## Issues fixed

1. #154 

## Show-n-Tell

https://youtu.be/YjM67s6RHas
