### PR TITLE
fix: Remove unused code

### DIFF
--- a/dcapal-backend/src/ports/outbound/adapter/kraken.rs
+++ b/dcapal-backend/src/ports/outbound/adapter/kraken.rs
@@ -1,13 +1,14 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Debug,
+};
+
 use failsafe::futures::CircuitBreaker;
 use futures::StreamExt;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Deserialize};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    fmt::Debug,
-};
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -483,8 +484,9 @@ async fn fetch_assets(
 }
 
 mod fiat {
-    use lazy_static::lazy_static;
     use std::collections::HashMap;
+
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref FIAT_IDS: HashMap<&'static str, &'static str> = HashMap::from([
@@ -525,7 +527,7 @@ fn get_kraken_api_periods(freq: OHLCFrequency) -> &'static str {
 }
 
 #[derive(Debug, Clone)]
-struct KAssetsDataCurrency {
+pub struct KAssetsDataCurrency {
     symbol: String,
     name: String,
     is_fiat: bool,
@@ -548,12 +550,6 @@ impl Into<Asset> for KAssetsDataCurrency {
     }
 }
 
-#[derive(Debug, Clone)]
-struct KAssetData {
-    _base: KAssetsDataCurrency,
-    _quote: KAssetsDataCurrency,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct OHLCResult {
     error: Vec<String>,
@@ -563,7 +559,7 @@ struct OHLCResult {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 enum Payload {
-    Last(i64),
+    Last(()),
     CandleSticks(CandleSticks),
 }
 


### PR DESCRIPTION
The linter in the pipelines throws some errors:

```
error: struct `KAssetsDataCurrency` is never constructed
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:528:8
    |
528 | struct KAssetsDataCurrency {
    |        ^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`

error: struct `KAssetData` is never constructed
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:552:8
    |
552 | struct KAssetData {
    |        ^^^^^^^^^^

error: field `0` is never read
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:566:10
    |
566 |     Last(i64),
    |     ---- ^^^
    |     |
    |     field in this variant
    |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
566 |     Last(()),
    |          ~~
    
```
    
    This PR fixes these issues