### PR TITLE
bugfix: solve build errors

### DIFF
--- a/dcapal-backend/src/app/infra/utils.rs
+++ b/dcapal-backend/src/app/infra/utils.rs
@@ -63,9 +63,7 @@ where
 
     pub async fn get(&self) -> Option<ExpiringOnceCellValue<T>> {
         let lock = self.cell.read().await;
-        let Some(v) = lock.get() else {
-            return None;
-        };
+        let v = lock.get()?;
 
         if (self.is_expired)(v) {
             Some(ExpiringOnceCellValue {

--- a/dcapal-backend/src/ports/outbound/adapter/kraken.rs
+++ b/dcapal-backend/src/ports/outbound/adapter/kraken.rs
@@ -1,13 +1,14 @@
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Debug,
+};
+
 use failsafe::futures::CircuitBreaker;
 use futures::StreamExt;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Deserialize};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    fmt::Debug,
-};
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -483,8 +484,9 @@ async fn fetch_assets(
 }
 
 mod fiat {
-    use lazy_static::lazy_static;
     use std::collections::HashMap;
+
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref FIAT_IDS: HashMap<&'static str, &'static str> = HashMap::from([
@@ -525,7 +527,7 @@ fn get_kraken_api_periods(freq: OHLCFrequency) -> &'static str {
 }
 
 #[derive(Debug, Clone)]
-struct KAssetsDataCurrency {
+pub struct KAssetsDataCurrency {
     symbol: String,
     name: String,
     is_fiat: bool,
@@ -548,12 +550,6 @@ impl Into<Asset> for KAssetsDataCurrency {
     }
 }
 
-#[derive(Debug, Clone)]
-struct KAssetData {
-    _base: KAssetsDataCurrency,
-    _quote: KAssetsDataCurrency,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct OHLCResult {
     error: Vec<String>,
@@ -563,7 +559,7 @@ struct OHLCResult {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 enum Payload {
-    Last(i64),
+    Last(()),
     CandleSticks(CandleSticks),
 }
 


### PR DESCRIPTION
This PR solves some issues in the build step:

```
error: struct `KAssetsDataCurrency` is never constructed
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:528:8
    |
528 | struct KAssetsDataCurrency {
    |        ^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`

error: struct `KAssetData` is never constructed
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:552:8
    |
552 | struct KAssetData {
    |        ^^^^^^^^^^

error: field `0` is never read
   --> dcapal-backend/src/ports/outbound/adapter/kraken.rs:566:10
    |
566 |     Last(i64),
    |     ---- ^^^
    |     |
    |     field in this variant
    |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
566 |     Last(()),
    |          ~~

error: this `let...else` may be rewritten with the `?` operator
  --> dcapal-backend/src/app/infra/utils.rs:66:9
   |
66 | /         let Some(v) = lock.get() else {
67 | |             return None;
68 | |         };
   | |__________^ help: replace it with: `let v = lock.get()?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `-D clippy::question-mark` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`

error: could not compile `dcapal-backend` (lib) due to 4 previous errors
```