### PR TITLE
ci: rework workflow layout and caching

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   backend-format:
+    name: check:fmt:backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -28,6 +29,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   backend-lint:
+    name: check:lint:backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -52,6 +54,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
   backend-test:
+    name: test:backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -69,6 +72,7 @@ jobs:
         run: RUST_LOG=dcapal-backend=debug cargo test -- --nocapture
 
   backend-openapi-check:
+    name: check:openapi:backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -88,6 +92,7 @@ jobs:
         run: git diff --exit-code -- dcapal-backend/docs/openapi.json
 
   optimizer-lint:
+    name: check:lint:optimizer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -114,6 +119,7 @@ jobs:
           cargo clippy -- -D warnings
 
   optimizer-build-test:
+    name: build:test:optimizer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -151,6 +157,7 @@ jobs:
           path: dcapal-optimizer-wasm/pkg
 
   frontend-format:
+    name: check:fmt:frontend
     runs-on: ubuntu-slim
     needs: optimizer-build-test
     steps:
@@ -177,6 +184,7 @@ jobs:
         run: npm run check
 
   frontend-typecheck:
+    name: check:typecheck:frontend
     runs-on: ubuntu-slim
     needs: optimizer-build-test
     steps:
@@ -203,6 +211,7 @@ jobs:
         run: npm run typecheck
 
   frontend-build-test:
+    name: build:test:frontend
     runs-on: ubuntu-latest
     needs: optimizer-build-test
     steps:
@@ -233,6 +242,7 @@ jobs:
         run: npm run test:unit
 
   frontend-e2e-tests:
+    name: test:e2e:frontend
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: optimizer-build-test
@@ -280,6 +290,7 @@ jobs:
           retention-days: 30
 
   backend-smoke-test:
+    name: test:smoke:backend
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,19 +6,40 @@ on:
   pull_request:
     branches: ["master", "dev", "rc/**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  backend-build-test:
+  backend-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          components: clippy, rustfmt
+          components: rustfmt
+
+      - name: Check backend formatting
+        working-directory: dcapal-backend
+        run: cargo fmt --all -- --check
+
+  backend-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+      # Share dependency, target, and installed Rust binary data across Rust jobs.
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          shared-key: rust
 
       - name: Toolchain info
         run: |
@@ -26,28 +47,39 @@ jobs:
           rustc --version
           cargo clippy --version
 
-      - name: Install SeaORM CLI
-        run: cargo install sea-orm-cli
+      - name: Lint backend
+        working-directory: dcapal-backend
+        run: cargo clippy -- -D warnings
 
-      - name: Lint
-        run: |
-          cd dcapal-backend
-          cargo fmt --all -- --check
-          cargo clippy -- -D warnings
+  backend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      # Share dependency, target, and installed Rust binary data across Rust jobs.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          shared-key: rust
 
-      - name: Build and Test
-        run: |
-          cd dcapal-backend
-          RUST_LOG=dcapal-backend=debug cargo test -- --nocapture
+      - name: Test backend
+        working-directory: dcapal-backend
+        run: RUST_LOG=dcapal-backend=debug cargo test -- --nocapture
 
   backend-openapi-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+      # Share dependency, target, and installed Rust binary data across Rust jobs.
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          shared-key: rust
 
       - name: Generate OpenAPI spec
         run: make export-openapi
@@ -55,15 +87,44 @@ jobs:
       - name: Verify OpenAPI spec is up to date
         run: git diff --exit-code -- dcapal-backend/docs/openapi.json
 
-  optimizer-build-test:
+  optimizer-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: clippy, rustfmt
+      # Share dependency, target, and installed Rust binary data across Rust jobs.
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          shared-key: rust
+
+      - name: Toolchain info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
+
+      - name: Lint optimizer
+        working-directory: dcapal-optimizer-wasm
+        run: |
+          cargo fmt -- --check
+          cargo clippy -- -D warnings
+
+  optimizer-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      # Share dependency, target, and installed Rust binary data across Rust jobs.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1
+          shared-key: rust
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -72,84 +133,151 @@ jobs:
         run: |
           cargo --version --verbose
           rustc --version
-          cargo clippy --version
 
-      - name: Lint
+      - name: Test optimizer
+        working-directory: dcapal-optimizer-wasm
         run: |
-          cd dcapal-optimizer-wasm
-          cargo fmt -- --check
-          cargo clippy -- -D warnings
-
-      - name: Test
-        run: |
-          cd dcapal-optimizer-wasm
           RUST_LOG=info cargo test -- --nocapture
           wasm-pack test --headless --chrome
 
-      - name: Build
-        run: |
-          cd dcapal-optimizer-wasm
-          wasm-pack build
+      - name: Build optimizer package
+        working-directory: dcapal-optimizer-wasm
+        run: wasm-pack build
 
       - name: Archive dcapal-optimizer-wasm pkg
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dcapal-optimizer-wasm-pkg
           path: dcapal-optimizer-wasm/pkg
 
-  frontend-check:
+  frontend-format:
     runs-on: ubuntu-slim
     needs: optimizer-build-test
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
+          cache: npm
           cache-dependency-path: dcapal-frontend/package-lock.json
 
-      - name: Check formatting
-        run: |
-          cd dcapal-frontend
-          npm ci
-          npm run check
-
-      - name: Typecheck
-        run: |
-          cd dcapal-frontend
-          npm run typecheck
-
-  frontend-build-test:
-    runs-on: ubuntu-latest
-    needs: [frontend-check, optimizer-build-test]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: dcapal-frontend/package-lock.json
-
+      # The generated package is a local npm dependency and must exist before npm ci.
       - name: Download dcapal-optimizer-wasm pkg
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dcapal-optimizer-wasm-pkg
           path: dcapal-optimizer-wasm/pkg
 
       - name: Install dependencies
-        run: |
-          cd dcapal-frontend
-          npm ci
+        working-directory: dcapal-frontend
+        run: npm ci
 
-      - name: Build
-        run: |
-          cd dcapal-frontend
-          npm run build
+      - name: Check frontend formatting
+        working-directory: dcapal-frontend
+        run: npm run check
+
+  frontend-typecheck:
+    runs-on: ubuntu-slim
+    needs: optimizer-build-test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: dcapal-frontend/package-lock.json
+
+      # The generated package is a local npm dependency and must exist before npm ci.
+      - name: Download dcapal-optimizer-wasm pkg
+        uses: actions/download-artifact@v8
+        with:
+          name: dcapal-optimizer-wasm-pkg
+          path: dcapal-optimizer-wasm/pkg
+
+      - name: Install dependencies
+        working-directory: dcapal-frontend
+        run: npm ci
+
+      - name: Typecheck frontend
+        working-directory: dcapal-frontend
+        run: npm run typecheck
+
+  frontend-build-test:
+    runs-on: ubuntu-latest
+    needs: optimizer-build-test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: dcapal-frontend/package-lock.json
+
+      # The generated package is a local npm dependency and must exist before npm ci.
+      - name: Download dcapal-optimizer-wasm pkg
+        uses: actions/download-artifact@v8
+        with:
+          name: dcapal-optimizer-wasm-pkg
+          path: dcapal-optimizer-wasm/pkg
+
+      - name: Install dependencies
+        working-directory: dcapal-frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: dcapal-frontend
+        run: npm run build
 
       - name: Unit tests
-        run: |
-          cd dcapal-frontend
-          npm run test:unit
+        working-directory: dcapal-frontend
+        run: npm run test:unit
+
+  frontend-e2e-tests:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    needs: optimizer-build-test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: dcapal-frontend/package-lock.json
+
+      # The generated package is a local npm dependency and must exist before npm ci.
+      - name: Download dcapal-optimizer-wasm pkg
+        uses: actions/download-artifact@v8
+        with:
+          name: dcapal-optimizer-wasm-pkg
+          path: dcapal-optimizer-wasm/pkg
+
+      - name: Install dependencies
+        working-directory: dcapal-frontend
+        run: npm ci
+
+      # Version the browser cache so Playwright upgrades invalidate old binaries.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-v1-${{ hashFiles('dcapal-frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-ms-playwright-v1-
+
+      - name: Install Playwright Browsers
+        working-directory: dcapal-frontend
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        working-directory: dcapal-frontend
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: dcapal-frontend/playwright-report/
+          retention-days: 30
 
   backend-smoke-test:
     timeout-minutes: 60
@@ -160,23 +288,44 @@ jobs:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
       POSTGRES_DB: postgres
+      SUPABASE_VERSION: 2.110.0
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: ".nvmrc"
+
+      # Supabase setup-cli installs the pinned package through npm.
+      - name: Cache Supabase CLI npm packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-supabase-cli-${{ env.SUPABASE_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-supabase-cli-
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v3
+        with:
+          version: ${{ env.SUPABASE_VERSION }}
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+
       - name: Build dcapal-backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./dcapal-backend/docker/Dockerfile
           load: true
           push: false
           tags: dcapal-backend:smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Smoke owns its scope and reads the publish scope for shared layers.
+          cache-from: |
+            type=gha,scope=dcapal-backend-smoke
+            type=gha,scope=dcapal-backend-publish
+          cache-to: type=gha,scope=dcapal-backend-smoke,mode=max,ignore-error=true
+
       - name: Configure dcapal env
         run: |
           cat > dcapal-backend/dcapal.env << EOF
@@ -186,6 +335,7 @@ jobs:
           POSTGRES_DB=${POSTGRES_DB}
           POSTGRES_PORT=${POSTGRES_PORT}
           EOF
+
       - name: Configure dcapal.yml
         run: |
           cat > dcapal-backend/dcapal.yml << EOF
@@ -221,6 +371,7 @@ jobs:
               password: ${POSTGRES_PASSWORD}
               database: ${POSTGRES_DB}
           EOF
+
       - name: Configure docker compose override
         run: |
           cat > dcapal-backend/docker-compose.override.yml << EOF
@@ -229,8 +380,10 @@ jobs:
               image: dcapal-backend:smoke
               env_file: dcapal.env
           EOF
-      - name: Install Supabase
-        run: make supabase-up
+
+      - name: Start Supabase
+        run: cd dcapal-backend && supabase start --workdir ./config
+
       - name: Run backend stack and wait for health
         run: |
           cd dcapal-backend
@@ -238,6 +391,7 @@ jobs:
                          -f ./docker/docker-compose.local.yml \
                          -f docker-compose.override.yml \
                          up --no-build --wait --wait-timeout 120
+
       - name: Print backend logs on failure
         if: failure()
         run: |
@@ -246,6 +400,7 @@ jobs:
                          -f ./docker/docker-compose.local.yml \
                          -f docker-compose.override.yml \
                          logs
+
       - name: Stop backend stack
         if: always()
         run: |
@@ -254,47 +409,7 @@ jobs:
                          -f ./docker/docker-compose.local.yml \
                          -f docker-compose.override.yml \
                          down
+
       - name: Stop Supabase
         if: always()
-        run: make supabase-down
-
-  frontend-e2e-tests:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    needs: [frontend-check, optimizer-build-test]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: dcapal-frontend/package-lock.json
-      - name: Download dcapal-optimizer-wasm pkg
-        uses: actions/download-artifact@v7
-        with:
-          name: dcapal-optimizer-wasm-pkg
-          path: dcapal-optimizer-wasm/pkg
-
-      - name: Install dependencies
-        run: cd dcapal-frontend && npm ci
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('dcapal-frontend/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-ms-playwright-
-
-      - name: Install Playwright Browsers
-        run: cd dcapal-frontend && npx playwright install --with-deps
-
-      - name: Run Playwright tests
-        run: cd dcapal-frontend && npx playwright test
-
-      - uses: actions/upload-artifact@v6
-        if: always()
-        with:
-          name: playwright-report
-          path: dcapal-frontend/playwright-report/
-          retention-days: 30
+        run: cd dcapal-backend && supabase stop --workdir ./config

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -321,7 +321,23 @@ jobs:
           version: ${{ env.SUPABASE_VERSION }}
 
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v4
+
+      - uses: actions/cache@v6
+        id: rust-docker-cache
+        with:
+          path: ${{ runner.temp }}/docker-rust-cache
+          key: ubuntu-docker-rust-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'dcapal-backend/docker/Dockerfile') }}
+          restore-keys: |
+            ubuntu-docker-rust-
+
+      - uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-dir: ${{ runner.temp }}/docker-rust-cache
+          dockerfile: dcapal-backend/docker/Dockerfile
+          skip-extraction: ${{ steps.rust-docker-cache.outputs.cache-hit }}
 
       - name: Build dcapal-backend image
         uses: docker/build-push-action@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   extract-tag-version:
+    name: resolve:release:version
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
@@ -27,6 +28,7 @@ jobs:
           echo ${{ env.RELEASE_VERSION }}
 
   build-publish-docker-image:
+    name: build:backend:image
     runs-on: ubuntu-latest
     needs: [extract-tag-version]
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
   extract-tag-version:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract tag version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Echo tag version
@@ -28,9 +28,9 @@ jobs:
 
   build-publish-docker-image:
     runs-on: ubuntu-latest
-    needs: [ extract-tag-version ]
+    needs: [extract-tag-version]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -39,35 +39,22 @@ jobs:
           images: |
             ${{ env.DOCKER_REPO }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./dcapal-backend/docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  
+          # Publish owns its scope and reads the smoke scope for shared layers.
+          cache-from: |
+            type=gha,scope=dcapal-backend-smoke
+            type=gha,scope=dcapal-backend-publish
+          cache-to: type=gha,scope=dcapal-backend-publish,mode=max,ignore-error=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,24 @@ jobs:
           images: |
             ${{ env.DOCKER_REPO }}
       - name: Set up Docker Buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v4
+
+      - uses: actions/cache@v6
+        id: rust-docker-cache
+        with:
+          path: ${{ runner.temp }}/docker-rust-cache
+          key: ubuntu-docker-rust-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'dcapal-backend/docker/Dockerfile') }}
+          restore-keys: |
+            ubuntu-docker-rust-
+
+      - uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-dir: ${{ runner.temp }}/docker-rust-cache
+          dockerfile: dcapal-backend/docker/Dockerfile
+          skip-extraction: ${{ steps.rust-docker-cache.outputs.cache-hit }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:

--- a/dcapal-backend/docker/Dockerfile
+++ b/dcapal-backend/docker/Dockerfile
@@ -1,6 +1,10 @@
+# syntax=docker/dockerfile:1.7
+
 # Bookworm, so it's the same as the runtime
 FROM rust:1-bookworm AS chef
-RUN cargo install cargo-chef
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    cargo install cargo-chef
 WORKDIR /var/dcapal
 
 FROM chef AS planner
@@ -17,13 +21,22 @@ COPY --from=planner /var/dcapal/recipe.json recipe.json
 RUN apt-get update
 RUN apt-get install build-essential cmake perl pkg-config libclang-dev musl-tools git -y
 
-RUN cargo chef cook --profile release-with-debug --recipe-path recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/var/dcapal/target \
+    cargo chef cook --profile release-with-debug --recipe-path recipe.json
 # Build application
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./dcapal-backend ./dcapal-backend
 COPY ./dcapal-optimizer-wasm ./dcapal-optimizer-wasm
-RUN cargo build --profile release-with-debug --bin dcapal-backend --bin migration
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/var/dcapal/target \
+    cargo build --profile release-with-debug --bin dcapal-backend --bin migration \
+    && mkdir -p /var/dcapal/output \
+    && cp /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/output/dcapal-backend \
+    && cp /var/dcapal/target/release-with-debug/migration /var/dcapal/output/migration
 
 FROM debian:bookworm-slim AS runtime
 # Install runtime dependencies
@@ -34,8 +47,8 @@ RUN apt-get install -y ca-certificates curl libssl3 jq postgresql-client
 WORKDIR /var/dcapal/dcapal-backend
 RUN mkdir bin
 RUN mkdir data
-COPY --from=builder /var/dcapal/target/release-with-debug/dcapal-backend /var/dcapal/dcapal-backend/bin
-COPY --from=builder /var/dcapal/target/release-with-debug/migration /var/dcapal/dcapal-backend/bin
+COPY --from=builder /var/dcapal/output/dcapal-backend /var/dcapal/dcapal-backend/bin
+COPY --from=builder /var/dcapal/output/migration /var/dcapal/dcapal-backend/bin
 COPY ./dcapal-backend/migration ./migration
 COPY ./dcapal-backend/migration/Cargo.toml ./migration/Cargo.toml
 COPY ./dcapal-backend/migration/src ./migration/src

--- a/dcapal-backend/src/lib.rs
+++ b/dcapal-backend/src/lib.rs
@@ -299,7 +299,7 @@ fn build_redis_pool(config: &config::Redis) -> Result<deadpool_redis::Pool> {
             DcaError::StartupFailure(
                 format!(
                     "Error in building Redis poll config (user={}, hostname={}, port={})",
-                    &config.user, &config.hostname, &config.port
+                    config.user, config.hostname, config.port
                 ),
                 e.into(),
             )
@@ -323,7 +323,7 @@ async fn build_postgres_pool(config: &Postgres) -> Result<PgPool> {
             DcaError::StartupFailure(
                 format!(
                     "Error in building Postgres poll config (user={}, hostname={}, port={}, db={})",
-                    &config.user, &config.hostname, &config.port, &config.database
+                    config.user, config.hostname, config.port, config.database
                 ),
                 e.into(),
             )


### PR DESCRIPTION
Closes #703

## What changed

- Split CI into independent backend, optimizer, frontend, OpenAPI, smoke, and end-to-end checks.
- Added CI cancellation for superseded branch and pull-request runs.
- Made the generated optimizer package an explicit artifact prerequisite before every frontend `npm ci`.
- Shared Rust caches across compilation jobs and added lockfile-keyed npm, Playwright, and pinned Supabase CLI caches.
- Replaced the unscoped/local Docker caches with separate smoke and publish GitHub Actions BuildKit scopes that can read one another without sharing a writer.
- Upgraded the selected GitHub Actions and Docker action majors.

## Why

Clean frontend runners could fail before formatting or typechecking because the local optimizer package was missing. Rust and Docker cache ownership also limited reuse and allowed avoidable cache contention. This keeps the existing validation commands, smoke-test behavior, release triggers, image metadata, tags, and push behavior while improving CI reuse and feedback time.