### PR TITLE
docs: add Wayfinder market-data research

### DIFF
--- a/dcapal-backend/CONTEXT.md
+++ b/dcapal-backend/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: Conversion rate, when the price belongs to a specific market
 The price of one known asset in another known asset, obtained from a direct market or from intermediary markets. When the two assets are the same, the conversion rate is one.
 _Avoid_: Market price, when the value is not tied to one specific market; trade price
 
+**Price series**:
+An ordered set of daily provider observations for a provider-bound market, with a source timestamp and value for each point.
+_Avoid_: Historical chart, when referring to stored market data
+
 **Market data provider**:
 An external service that discovers market assets and markets or supplies market prices to DcaPal Backend.
 _Avoid_: Portfolio asset provider; broker

--- a/dcapal-frontend/CONTEXT.md
+++ b/dcapal-frontend/CONTEXT.md
@@ -101,7 +101,7 @@ A named formula, rule, or literature-based approach that suggests strategic asse
 _Avoid_: Financial advice, automatic recommendation
 
 **Drift band**:
-An acceptable range around a target weight used to decide whether to surface drift or recommend rebalancing. Drift bands are expressed in percentage points and may be configured separately for Asset Classes and Portfolio Assets.
+An optional Portfolio-wide range around each target weight used to decide whether to surface drift or recommend rebalancing. It is expressed in percentage points; a missing value disables drift diagnostics. Asset- and Asset Class-specific overrides are not part of this MVP.
 _Avoid_: Confidence band, when referring to a rebalancing threshold
 
 **Model performance history**:
@@ -123,11 +123,11 @@ New money or liquidity available for the current allocation. It is separate from
 _Avoid_: Portfolio value, balance
 
 **Allocation**:
-A recommendation for distributing the investment budget among portfolio assets to move projected weights towards target weights. It may include unallocated cash and is not an executed trade.
+A buy-only recommendation for distributing the investment budget among Portfolio Assets to move projected weights towards target weights. It may include unallocated cash and is not an executed trade.
 _Avoid_: Order, transaction, full rebalancing
 
 **Rebalancing**:
-Changing existing holdings, including possible sales, to restore target weights. A buy-only allocation can improve balance without being a full rebalancing.
+Changing existing holdings to restore target weights. It may sell eligible overweight Portfolio Assets and use their proceeds, together with the investment budget, to buy underweight assets. A buy-only allocation can improve balance without being a full rebalancing.
 _Avoid_: Allocation, when sales are part of the intended action
 
 **Buy-only mode**:
@@ -147,6 +147,14 @@ The part of the investment budget that an allocation recommendation does not ass
 _Avoid_: Unused portfolio value, cash asset, unless the quote currency is actually included as a portfolio asset
 
 ## Fee and market-data language
+
+**Effective price**:
+The price currently used to value a Portfolio asset. Its provenance is explicit: manual price, current provider price, or last-known provider price.
+_Avoid_: Current price, when the source or freshness matters
+
+**Historical price series**:
+An ordered set of daily provider price observations for an Asset, used to calculate Model performance history. It begins at the first real observation available and is not a transaction history.
+_Avoid_: Price chart, transaction history, when referring to the source data
 
 **Transaction fee policy**:
 A rule used to estimate the cost of buying a portfolio asset during an allocation. It can be zero, fixed, or variable, and may include a maximum fee impact.

--- a/docs/research/issue-762-yahoo-historical-provider-contract.md
+++ b/docs/research/issue-762-yahoo-historical-provider-contract.md
@@ -1,0 +1,58 @@
+# Finding: Yahoo historical market data and crypto-provider boundary
+
+**Context:** [GitHub issue #762](https://github.com/dcapal/dcapal/issues/762), “Research: Verify Yahoo Finance historical coverage and FX authority”.
+
+**Research date:** 2026-08-05
+
+## Finding
+
+For this MVP, Yahoo Finance is the authoritative provider for non-crypto market data and FX conversion series, and Kraken is the authoritative crypto source. CryptoWatch is not an acceptable fallback or parallel source. A Yahoo failure must remain a Yahoo failure; it must not silently become a Kraken or other-provider result.
+
+This conclusion is partly a repository-contract finding, not a claim that Yahoo publishes a complete public contract for its chart endpoint. Yahoo’s first-party material confirms broad coverage and important restrictions, but does not publish the exact undocumented chart-endpoint limits needed to promise arbitrary intraday history.
+
+## Yahoo coverage and symbols
+
+Yahoo says historical data is available for “most quotes”, but that availability can be limited by data-licensing restrictions; where a requested range exceeds available history, Yahoo displays the available data. Yahoo also says historical prices usually do not go earlier than 1970. Its coverage page identifies exchanges, suffixes, delays, and underlying data providers, and states that the data is informational and must not be redistributed. ([Yahoo Help: download historical data](https://help.yahoo.com/kb/finance/download-historical-data-yahoo-finance-sln2311.html); [Yahoo Help: exchanges and data providers](https://help.yahoo.com/kb/yahoo-finance-plus/exchanges-data-providers-yahoo-finance-sln2310.html))
+
+The repository’s Yahoo adapter uses the chart endpoint `query1.finance.yahoo.com/v8/finance/chart/{symbol}` and the search endpoint `query2.finance.yahoo.com/v1/finance/search`. It maps ordinary assets to `{BASE}-{QUOTE}` and fiat pairs to `{BASE}{QUOTE}=X`, except that USD as the base is represented as `{QUOTE}=X`; it also contains the local `luna -> luna1` symbol exception. ([`yahoo.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/yahoo.rs#L120-L190))
+
+That mapping means the supported FX shape is a Yahoo currency symbol such as `EURUSD=X`, with the repository’s special inversion for USD-base markets. It does not establish that every fiat currency or every cross is covered: Yahoo’s own wording is “most quotes”, and licensing or missing-symbol responses are unsupported cases.
+
+## Intervals, timestamps, and depth
+
+The repository contract exposes only two OHLC frequencies: five minutes and one day. The Yahoo adapter sends them as `interval=5m` and `interval=1d`. For five-minute prices it asks for the 12 preceding five-minute periods ending at the current five-minute boundary; for daily prices it asks from the start of the previous day through the requested timestamp. It sends `period1` and `period2` as Unix seconds. ([`entity.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/app/domain/entity.rs#L122-L169); [`yahoo.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/yahoo.rs#L41-L53))
+
+The adapter currently reads only the last non-null `close` value from the first chart result and does not read Yahoo’s bar timestamps. The stored DcaPal `Price` timestamp is the fetch time (`Utc::now()`), not the source bar timestamp. This is an existing behavior that a future implementation must preserve or deliberately change; it must not be described as source-time fidelity. ([`yahoo.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/yahoo.rs#L91-L117); [`market_data_utils.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/app/domain/market_data_utils.rs#L7-L20))
+
+Yahoo’s first-party help describes selectable date ranges and chart intervals, but it does not publish a precise maximum age for each undocumented chart API interval. Therefore the authoritative finding is:
+
+- `5m` and `1d` are the only intervals this repository promises.
+- Daily history may extend back only as far as Yahoo has data for the instrument, subject to the “usually not earlier than 1970” guidance and licensing.
+- Five-minute history must be treated as bounded and availability-dependent. The repository must not promise history beyond the range Yahoo actually returns, and it must not fabricate or substitute older bars.
+- Exact claims such as “5m is available for exactly N days” are not supported by Yahoo first-party documentation found for this issue and must not become a product guarantee. ([Yahoo Help: change chart period and scale](https://help.yahoo.com/kb/period-scale-screen-charts-yahoo-finance-web-sln28287.html); [Yahoo Help: download historical data](https://help.yahoo.com/kb/finance/download-historical-data-yahoo-finance-sln2311.html))
+
+## Rate limits, terms, and failures
+
+Yahoo’s published API terms say Yahoo may impose rate limits and quotas at its discretion, may suspend or terminate access, may change API specifications or access methods without notice, and provides APIs without a warranty of reliability, accuracy, completeness, or uninterrupted service. The terms also prohibit automated access other than through the APIs, actions that burden Yahoo infrastructure, and redistribution or use outside the permitted terms. No fixed public requests-per-minute limit for the chart endpoint is stated in the cited Yahoo material. ([Yahoo API Terms of Use](https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.html); [Yahoo API Terms and Conditions](https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apitnc/index.html))
+
+The repository therefore needs bounded request volume, caching, and explicit provider errors, but cannot claim a numeric Yahoo quota. It already spaces price-update requests by 100 ms, but that local delay is an application safeguard, not a Yahoo contractual rate limit. ([`price_updater.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/app/workers/price_updater.rs#L66-L82))
+
+Current Yahoo failure behavior is materially different by path: a transport failure in the internal price path propagates as an error; an HTTP 404 or a chart payload error becomes `None`; other non-success statuses propagate as errors. The proxy path returns the upstream status and body when a request succeeds, and returns `502 Bad Gateway` when the request cannot be sent. Empty or malformed successful chart payloads are errors. ([`yahoo.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/yahoo.rs#L64-L89); [`yahoo.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/yahoo.rs#L91-L149))
+
+This means missing coverage, an unsupported FX symbol, a licensing restriction, a rate-limit response, and a provider outage must remain observable as missing data or a provider error according to the path. They must not trigger a silent provider substitution.
+
+## Crypto source and complete CryptoWatch removal
+
+Kraken is the supported crypto source in the repository. Market discovery obtains online pairs from Kraken `AssetPairs`; price retrieval uses Kraken’s public `OHLC` endpoint with the repository’s five-minute and daily mappings. Kraken documents that OHLC supports minute intervals including 5 and 1440, returns the current uncommitted candle, and returns at most 720 recent entries. Its public API rate-limit guidance documents the call counter, tiered limits, decay, and the `EAPI:Rate limit exceeded` / throttling errors. ([Kraken: tradable asset pairs](https://docs.kraken.com/api-reference/market-data/get-tradable-asset-pairs); [Kraken: OHLC data](https://docs.kraken.com/api-reference/market-data/get-ohlc-data); [Kraken: Spot REST rate limits](https://docs.kraken.com/exchange/guides/rest/ratelimits))
+
+At this repository snapshot, CryptoWatch is still wired into configuration, provider construction, dispatch, and the adapter module, while Kraken already owns crypto discovery. Specifically, the code still has a `CryptoWatch` enum variant and API-key field, constructs a `CryptoWatchProvider`, exposes it through `PriceProviders`, dispatches to it, and retains `cw.rs`. ([`config.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/config.rs#L5-L11); [`config.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/config.rs#L34-L42); [`adapter/mod.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/mod.rs#L1-L29); [`market_data_utils.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/app/domain/market_data_utils.rs#L12-L17); [`lib.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/lib.rs#L144-L152); [`cw.rs`](https://github.com/dcapal/dcapal/blob/f652260/dcapal-backend/src/ports/outbound/adapter/cw.rs))
+
+“Complete CryptoWatch removal” therefore means removing those code and configuration paths and any `CW`/`cw_api_key` deployment or documentation references, then making the provider selection explicit: Yahoo for non-crypto assets and FX, Kraken for crypto. A failed Yahoo request must not fall through to Kraken, and a failed Kraken request must not fall through to Yahoo.
+
+## Decision boundary for implementation
+
+1. Keep Yahoo as the only provider for non-crypto assets and FX conversion series.
+2. Keep only `5m` and `1d` in the MVP Yahoo contract; treat coverage and intraday depth as provider-returned availability, not guaranteed history.
+3. Use Unix-second `period1`/`period2` requests and the repository’s existing symbol rules, including `=X` FX symbols and the `luna1` exception.
+4. Preserve source/provider identity in errors and missing-data outcomes; do not substitute providers.
+5. Use Kraken as the sole crypto provider and remove CryptoWatch completely, including configuration, construction, dispatch, module, secrets, and docs.

--- a/docs/research/supabase-auth-mocking-options.md
+++ b/docs/research/supabase-auth-mocking-options.md
@@ -1,0 +1,87 @@
+# Findings: minimal Supabase auth mock for frontend tests
+
+Research date: 2026-08-05
+
+## Context
+
+- Ticket: [Research: Evaluate a minimal Supabase auth mock](https://github.com/dcapal/dcapal/issues/759)
+- Parent map: [Portfolio management hub and allocation workflows](https://github.com/dcapal/dcapal/issues/742)
+
+This is a research finding, not a product-code change. It checks the frontend's current Supabase calls and compares maintained or credible test options against the request's constraints: no Supabase server, no production runtime dependency, and only the consumed auth/session surface.
+
+## Executive finding
+
+No small, maintained, Supabase-specific off-the-shelf double was found that satisfies all three constraints. The best fit is a test-only in-repository adapter at the `@app/config` seam. Keep the real `@supabase/supabase-js` client in production and use the existing MSW dependency only for the separate REST API boundary.
+
+The closest ready-made package is `@akirilyuk/supabase-in-memory-server`, but it starts a Node HTTP server and therefore fails the no-server requirement. `supabase-mock-fetch` avoids a server, but it mocks database-shaped fetch calls and does not provide the auth/session methods this frontend consumes. The preliminary note was directionally correct, but its “best fallback” should be described as an integration-test option, not as a candidate for ordinary local or CI frontend tests.
+
+## Consumed client surface
+
+The production client is created with `createClient` in [`dcapal-frontend/src/app/config.js`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/app/config.js#L1-L19). Direct application callers use:
+
+| Method | Repository use | Minimum double contract |
+| --- | --- | --- |
+| `auth.getSession()` | App startup, router, portfolio sync, API access-token callback | Resolve `{ data: { session }, error: null }`, including `session: null` |
+| `auth.refreshSession()` | API access-token refresh callback | Resolve a configured session or error |
+| `auth.getUser()` | Navigation-bar user display | Resolve `{ data: { user }, error: null }` |
+| `auth.signOut()` | API auth failure and navigation logout | Clear the fixture session and resolve `{ error: null }` or a configured error |
+| `auth.onAuthStateChange(callback)` | Router, portfolio sync, login, and signup | Register callbacks and return `{ data: { subscription: { unsubscribe } } }` |
+
+These calls are visible in [`src/index.js`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/index.js#L34-L61), [`src/routes/router.js`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/routes/router.js#L31-L55), [`src/hooks/useSyncPortfolios.tsx`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/hooks/useSyncPortfolios.tsx#L56-L79), and [`src/components/core/navBar.js`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/components/core/navBar.js#L135-L167). Login and signup also pass the client to Supabase Auth UI components ([login](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/routes/loginPage.js#L68-L91), [signup](https://github.com/dcapal/dcapal-frontend/src/routes/signUpPage.js#L104-L119)). That is a component integration boundary, not evidence that the application needs to implement every Supabase Auth method.
+
+Supabase documents that `getSession` reads client storage and can return `null`, while `getUser` authenticates by contacting the Auth server. It documents `refreshSession`, `signOut`, and the subscription returned by `onAuthStateChange` separately ([`getSession`](https://supabase.com/docs/reference/javascript/auth-getsession#retrieve-a-session), [`getUser`](https://supabase.com/docs/reference/javascript/auth-getuser), [`refreshSession`](https://supabase.com/docs/reference/javascript/auth-refreshsession), [`signOut`](https://supabase.com/docs/reference/javascript/auth-signout), [`onAuthStateChange`](https://supabase.com/docs/reference/javascript/auth-onauthstatechange)). The double should preserve these distinct call shapes, but it need not reproduce storage, JWT, or network authenticity.
+
+## Options compared
+
+### A. Narrow in-repository adapter — recommended
+
+Create a fresh test-only object with an `auth` property exposing the five methods above. Give it an explicit session fixture, user fixture, configurable errors, and a subscriber set. `setSession` or `emitAuthChange` can drive authenticated and anonymous states; `signOut` should clear the session and notify subscribers; `unsubscribe` should remove exactly one callback.
+
+**Fit:** exact. It has no server, no network request, no new package, and no production bundle impact. It also makes the contract visible: adding a new Supabase call causes a deliberate test-double change.
+
+**Limit:** it tests application session handling, not Supabase protocol behavior, refresh-token rotation, OAuth redirects, JWT validity, or RLS. Those are separate integration concerns.
+
+### B. `supabase-mock-fetch` — not sufficient
+
+The package README describes a Map-backed mock `fetch` implementation for Supabase-style database operations, including REST-like GET/POST/PATCH/DELETE examples ([README](https://github.com/nurulhudaapon/supabase-mock-fetch/blob/main/README.md)). Its published manifest is version `0.0.0-alpha.1` and has no runtime dependencies ([package manifest](https://raw.githubusercontent.com/nurulhudaapon/supabase-mock-fetch/main/package.json)); npm currently lists versions through `0.0.0-alpha.2` ([npm metadata](https://registry.npmjs.org/supabase-mock-fetch)). The repository's latest push was 2025-01-22 ([GitHub repository metadata](https://api.github.com/repos/nurulhudaapon/supabase-mock-fetch)).
+
+**Fit:** no server and could be test-only, but poor API fit. Its documented surface is fetch/database handling; it does not expose `auth.getSession`, `refreshSession`, `getUser`, `signOut`, or `onAuthStateChange`. It would leave the main auth double to implement locally, while adding an alpha package for a different boundary.
+
+### C. `@akirilyuk/supabase-in-memory-server` — integration fallback, not default
+
+This package is a more capable community option. Its README documents an in-memory HTTP server that mimics PostgREST and GoTrue, a helper that creates a real Supabase client, and auth routes for signup, password/refresh-token exchange, logout, and get-user ([README](https://github.com/akirilyuk/supabase-in-memory-server/blob/main/README.md)). Its package manifest declares Node 20.9+/22+, a peer dependency on `@supabase/supabase-js`, and Winston ([package manifest](https://raw.githubusercontent.com/akirilyuk/supabase-in-memory-server/main/package.json)); npm lists version `1.0.1` ([npm metadata](https://registry.npmjs.org/@akirilyuk%2Fsupabase-in-memory-server)).
+
+**Fit:** good when the test goal is exercising the real SDK over HTTP. It fails this ticket's ordinary-test constraint because `createMemorySupabaseServer` starts a Node listener, and the README lists meaningful gaps including OAuth/SSO, OTP, MFA, password recovery, refresh edge cases, RLS, Realtime, Storage, and Edge Functions. Keep it as a possible future integration lane, not as the default auth fixture.
+
+### D. Existing MSW plus the real Supabase client — credible but broader than needed
+
+The frontend already has MSW as a development dependency ([`dcapal-frontend/package.json`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/package.json#L65-L93)) and starts it for browser journeys ([`src/index.js`](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/index.js#L63-L84)). MSW can intercept browser and Node requests without a separate Supabase service, but using it for Auth would require emulating the GoTrue HTTP protocol and the client’s storage/token lifecycle. It would test more real `supabase-js` behavior than an object adapter, but it is a protocol fixture, not a small client double, and it creates more state and response-shape maintenance than the five-method seam requires.
+
+**Fit:** viable for a later SDK/protocol integration scenario; not the narrowest answer to this issue. Keep MSW focused on the repository’s `/api` boundary unless a future test explicitly needs Supabase HTTP behavior.
+
+### E. Local Supabase CLI stack — out of scope for ordinary tests
+
+Supabase’s official testing guidance uses the local stack for database and integration testing ([testing overview](https://supabase.com/docs/guides/local-development/testing/overview), [database testing](https://supabase.com/docs/guides/database/testing)). This gives the highest service fidelity, but it requires the local Supabase services and is therefore not a no-server mock. It belongs in a separate integration lane for migrations, RLS, and service behavior.
+
+## Decision matrix
+
+| Criterion | In-repository adapter | `supabase-mock-fetch` | In-memory server | MSW + real client | Local Supabase stack |
+| --- | --- | --- | --- | --- | --- |
+| Exact consumed auth surface | Yes | No | Via HTTP, partial | Via HTTP, if emulated | Yes, real service |
+| New production runtime dependency | None | None if dev-only | None if dev-only, but test package | None; already present | CLI/services only |
+| Supabase server/listener | No | No | Node listener | No Supabase service, but HTTP handlers | Full local stack |
+| Tests real SDK behavior | No | Not for auth | Yes | Yes | Yes |
+| Ordinary local/CI fit | Best | Insufficient alone | Heavy | Medium/heavy | Poor |
+| Protocol/OAuth/RLS fidelity | Fixture-level | None for auth | Limited/documented gaps | Only what handlers model | Highest |
+
+## Recommendation and boundary
+
+Adopt the narrow in-repository adapter for unit and ordinary frontend CI tests. Keep production importing the real client from `@supabase/supabase-js` with `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. Select the adapter only through test configuration or dependency injection; do not export it from production config, ship fixture tokens, or use unsigned test tokens in a production bundle.
+
+The implementation should start with `getSession`, `refreshSession`, `getUser`, `signOut`, and `onAuthStateChange`. Add Auth UI methods only when an interaction test requires them. Add one contract test covering the return shapes, unsubscribe behavior, and sign-out notification. Retain a separate real-client/server test only when a change needs Supabase protocol, OAuth, refresh-token, JWT, or RLS confidence.
+
+This resolves the research question without changing product code or GitHub issue state.
+
+## Sources
+
+All external sources above are official Supabase documentation, first-party package metadata, or the source repositories/manifests for the compared packages. Repository citations point to the application code that defines the actual consumed surface.

--- a/docs/research/tanstack-query-persistent-series.md
+++ b/docs/research/tanstack-query-persistent-series.md
@@ -1,0 +1,146 @@
+# Findings: TanStack Query persistence for daily asset and FX series
+
+Research date: 2026-08-05
+
+## Context
+
+- Ticket: [Research: Verify TanStack Query persistent series caching](https://github.com/dcapal/dcapal/issues/758)
+- Parent product direction: [Portfolio management hub and allocation workflows](https://github.com/dcapal/dcapal/issues/742)
+
+This is a research finding, not a product-code change. It uses the current repository source and official TanStack Query documentation/source only.
+
+## Executive findings
+
+1. **Use TanStack Query persistence for the browser cache, with IndexedDB behind the official `Persister` interface.** The smallest supported design is `@tanstack/react-query-persist-client` plus a custom IndexedDB persister following TanStack's documented `idb-keyval` example. `createAsyncStoragePersister` is also official, but it is a generic `getItem`/`setItem`/`removeItem` adapter and its default JSON serialization is not the best fit for large series. There is no dedicated official TanStack IndexedDB adapter in the official package set inspected here.
+
+2. **Persist only successful asset/FX series queries.** Use `dehydrateOptions.shouldDehydrateQuery` to select the canonical series query family. Keep Zustand for client state and keep current prices out of this persisted series family. The persister stores a dehydrated QueryClient, not a separate time-series database.
+
+3. **Set `gcTime` at least as high as `maxAge`, and choose the two separately from `staleTime`.** `staleTime` controls when a series becomes eligible for refetch; `gcTime` controls removal of inactive in-memory queries; `maxAge` controls whether the persisted snapshot is accepted on restore. TanStack warns that the default hydration `gcTime` is five minutes, while persisted `maxAge` defaults to 24 hours, so leaving `gcTime` at its default can discard a valid persisted snapshot early.
+
+4. **Make the query key asset-series based, never Portfolio based.** A shared key should include every variable that changes the returned series—provider, canonical symbol or FX pair, source/quote currency, frequency, and the requested window—but not `portfolioId`. Every Portfolio that needs the same series then shares one QueryClient entry. The current repository already has one app-wide QueryClient and provider-price keys that are independent of Portfolio identity.
+
+5. **Use direct asset-series requests and a bounded daily tail refresh.** The historical contract should be an asset-level request, not a request that embeds a whole Portfolio. On a daily view, refetch only the newest one-month tail, merge observations by canonical observation date into the long-range cached series, and update the canonical query with `setQueryData`. This is an application reconciliation policy; TanStack persistence does not merge ranges or deduplicate daily points for the application.
+
+6. **A stale-cache refetch failure must preserve the last successful data and expose the failure.** TanStack Query reports the last successful `data` separately from `isRefetchError`/`error` and marks the result stale. The UI should show the series as stale or unavailable at its tail, retry later, and never replace a usable old series with an empty or invented series. A first-load failure with no cached data is a different state and should render as unavailable.
+
+## Current repository source
+
+### Query client and provider cache
+
+- The frontend creates one shared `QueryClient` for the application. Its current defaults disable query retries and window-focus refetching. [Frontend QueryClient](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/api/queryClient.ts#L1-L23)
+- Current price reads use a five-minute `staleTime`; Yahoo keys include provider, symbol, quote, and the sorted supported-currency list. DcaPal price keys come from the generated API client and include the asset and quote. These keys are already independent of Portfolio identity. [Provider query keys and options](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/api/priceProviders.ts#L113-L160)
+- The current Yahoo price adapter calls a four-day chart window and selects the newest valid close; this is a live-price fallback path, not a historical daily-series cache. [Yahoo current-price adapter](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/api/priceProviders.ts#L42-L110)
+
+### Existing historical boundary
+
+- The backend exposes an asset-level `GET /assets/chart/{symbol}` route with `startPeriod` and `endPeriod`, and forwards it to the Yahoo adapter. The route has no Portfolio identifier or persistent-series contract. [Chart route](https://github.com/dcapal/dcapal/blob/master/dcapal-backend/src/ports/inbound/rest/mod.rs#L171-L234)
+- The generated client creates a query key from the asset path and the request-parameter object: `['/assets/chart/${symbol}', params]`. This is a useful generated transport key, but the future canonical series key should be a deliberate domain key shared by all Portfolio consumers and should include the normalized series identity and frequency. [Generated chart query key](https://github.com/dcapal/dcapal/blob/master/packages/api-client/src/gen/index.ts#L243-L275)
+- The current chart response keeps only Yahoo `meta.currency` and close arrays. It does not preserve observation timestamps in the application-facing type, so a durable daily-series contract must add dated observations before reconciliation can be reliable. [Yahoo chart proxy types](https://github.com/dcapal/dcapal/blob/master/dcapal-backend/src/ports/inbound/rest/proxy_types.rs#L17-L49)
+- The frontend domain explicitly separates the historical Portfolio model series from current Portfolio value. A cloned Portfolio recomputes historical performance from asset time series rather than copying history. [Frontend domain context](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/CONTEXT.md#L1-L20) and [historical performance ADR](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/docs/adr/002-use-normalized-model-history.md#L1-L20)
+
+## Official TanStack Query findings
+
+### Smallest persistence design
+
+TanStack's v5 persistence plugin is `@tanstack/react-query-persist-client`. It defines a `Persister` with three operations: `persistClient`, `restoreClient`, and `removeClient`. `persistQueryClient` restores the snapshot and subscribes to later cache changes; `PersistQueryClientProvider` additionally prevents query fetches racing with asynchronous restore and exposes restore lifecycle callbacks. [Official persistence guide](https://tanstack.com/query/v5/docs/framework/react/plugins/persistQueryClient#persisters) and [provider guidance](https://tanstack.com/query/v5/docs/framework/react/plugins/persistQueryClient#persistqueryclientprovider)
+
+For this repository, the smallest production shape is:
+
+```ts
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { get, set, del } from "idb-keyval";
+
+const persister = {
+  persistClient: (client) => set("dcapal-series", client),
+  restoreClient: () => get("dcapal-series"),
+  removeClient: () => del("dcapal-series"),
+};
+```
+
+The snippet is an application sketch, not an implementation. TanStack's official example uses the same `idb-keyval` operations and says IndexedDB is preferable to Web Storage for larger data because it stores more than 5 MB and does not require serialization. [Official IndexedDB persister example](https://tanstack.com/query/v5/docs/framework/react/plugins/persistQueryClient#building-a-persister)
+
+`createAsyncStoragePersister` is a supported alternative when a storage object implements `getItem`, `setItem`, and `removeItem`; the official package defaults to JSON serialization and one-second write throttling. An IndexedDB wrapper can implement that interface, but a direct `Persister` is smaller and avoids treating IndexedDB as string storage. [Official async-storage adapter](https://tanstack.com/query/v5/docs/framework/react/plugins/createAsyncStoragePersister#options)
+
+The official package tree contains the persistence core and sync/async storage persister packages, while the IndexedDB example is documented as a custom persister. This supports using `idb-keyval` as a small direct dependency, not adding a speculative adapter abstraction. [TanStack persistence package](https://github.com/TanStack/query/tree/main/packages/react-query-persist-client) and [TanStack async-storage package](https://github.com/TanStack/query/tree/main/packages/query-async-storage-persister)
+
+### Persist a subset, not the whole application cache
+
+`dehydrate` persists successful queries by default and accepts `shouldDehydrateQuery` to decide which queries are included. The series persistence subscription should select only the canonical asset/FX series family. This keeps asset metadata, search results, authentication-adjacent data, and live current prices outside the large persisted payload. [Official dehydration reference](https://tanstack.com/query/v5/docs/framework/react/reference/hydration#dehydrate)
+
+### `staleTime`, `gcTime`, and persisted `maxAge`
+
+These values have different meanings:
+
+| Setting | Meaning for this design | Starting policy |
+| --- | --- | --- |
+| `staleTime` | How long a successfully fetched series is considered fresh. A stale query may refetch on mount, focus, or reconnect according to the other refetch settings. | Daily series: short enough to allow the one-month-tail policy after a day boundary; the exact duration is a product decision. Do not use `Infinity` for mutable daily data. |
+| `gcTime` | How long an inactive query remains in memory before garbage collection. It does not mean “how long the IndexedDB record is valid.” | At least the persisted `maxAge`; for a daily series, a multi-day or longer value is reasonable if the browser timer limit is handled. |
+| `maxAge` | Maximum age of the persisted snapshot at restore. An older snapshot is silently discarded and `removeClient()` is called for expired/busted/error/empty persisted data. | Match the offline continuity requirement, such as several days, and let the daily tail reconciliation revalidate the end. |
+
+TanStack's current defaults are `staleTime: 0` and inactive-query `gcTime: 5 minutes`; it documents `staleTime` as freshness and `gcTime` as inactive-cache lifetime. [Official defaults](https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults) and [useQuery option reference](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery#options)
+
+For persistence, TanStack specifically says that hydration uses a five-minute default `gcTime` when it is not overridden, and recommends `gcTime >= maxAge`; otherwise garbage collection can remove data earlier than the persisted max age. It also documents a roughly 24-day JavaScript timer limit unless the timeout provider is replaced. [Official persistence lifetime guidance](https://tanstack.com/query/v5/docs/framework/react/plugins/persistQueryClient#how-it-works)
+
+The persisted `maxAge` check is snapshot-wide. It is not a per-observation or per-query freshness check. Therefore a snapshot can be accepted while an individual daily series is stale; `staleTime`, refetch policy, and the tail reconciliation must handle that case.
+
+### Canonical keys and Portfolio reuse
+
+TanStack requires serializable array query keys and says every variable used by the query function that changes the result belongs in the key. Object properties are hashed deterministically, but array order matters. [Official query-key rules](https://tanstack.com/query/v5/docs/framework/react/guides/query-keys)
+
+Recommended domain shape:
+
+```ts
+["asset-series", {
+  provider: "yahoo",
+  symbol: "VWCE.DE",
+  quote: "EUR",
+  frequency: "daily",
+  from: "2025-08-05",
+  to: "2026-08-05",
+}]
+```
+
+The key must not contain `portfolioId`, target weights, quantity, or other Zustand state. Those values affect the derived Portfolio model series, not the underlying asset/FX observations. If two Portfolios ask for the same normalized identity and window, they share the cached and persisted query. If the request window changes, it is a different query and must be reconciled or fetched explicitly.
+
+### Direct-depth requests and daily one-month-tail reconciliation
+
+The current repository already has a direct asset chart boundary, so the smallest compatible design is an asset-series query function that calls that boundary directly. A Portfolio view composes the same asset-level query options for each holding and separately queries any required FX series. It does not issue a Portfolio-shaped historical request or include the Portfolio in the series key.
+
+For a daily series with a long requested range:
+
+1. Restore the canonical long-range query from IndexedDB.
+2. If its daily data is stale or the day boundary has passed, issue one direct request for `[today - 1 month, today]` for that same series identity.
+3. Merge returned observations by canonical UTC/business observation date. The tail replaces rows for dates it covers; older rows remain unchanged. Sort and deduplicate before storing.
+4. Write the merged result to the same long-range query key with `queryClient.setQueryData`, preserving the last successful data when the tail request fails.
+5. Persist the changed cache through the persistence subscription. Do not create one persisted query per Portfolio.
+
+This tail policy is an application rule inferred from the repository's asset-level chart boundary and the product's daily-series requirement. TanStack provides cache identity, hydration, refetch, and `setQueryData`; it does not know that two responses are date ranges of one logical series and will not merge them automatically. The merge must use a stable observation date and must not use fetch time as the row key.
+
+### Stale-cache failure behavior
+
+TanStack's `useQuery` reference defines `data` as the last successfully resolved data, `isRefetchError` as a failure during refetch, and `isStale` as true when data is invalidated or older than `staleTime`. Thus a failed tail refresh does not require discarding the old series. The UI can render the old series with an explicit stale/error state and retry later. [Official `useQuery` result reference](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery#returns)
+
+The persistence layer has a different failure rule: if restoring data finds an expired snapshot, a buster mismatch, an error, or an empty result, TanStack calls `removeClient()` and discards that persisted cache. That is correct for a corrupt or too-old snapshot, but it is not a reason to delete a valid in-memory series after a provider tail failure. [Official persistence removal rules](https://tanstack.com/query/v5/docs/framework/react/plugins/persistQueryClient#removal)
+
+The repository currently sets `retry: false`, so a future series query must either opt into bounded retries for transient provider failures or keep the current no-retry behavior and expose the stale state immediately. In either case, the result contract should distinguish: no cache and failed initial request; cached but stale and failed refresh; and cached, refreshed, and current. [Current repository retry default](https://github.com/dcapal/dcapal/blob/master/dcapal-frontend/src/api/queryClient.ts#L9-L20)
+
+## Recommended smallest design
+
+| Concern | Recommendation |
+| --- | --- |
+| State ownership | Zustand for Portfolio/client state; TanStack Query for asset/FX server state; live current prices remain separate. |
+| Persistence packages | `@tanstack/react-query-persist-client` plus a small custom IndexedDB `Persister` using the official `idb-keyval` pattern. Add `@tanstack/query-async-storage-persister` only if its generic storage interface is useful elsewhere. |
+| Provider | `PersistQueryClientProvider`, so async IndexedDB restore cannot race query mounts. |
+| Dehydration | Include only successful canonical asset/FX series queries with `shouldDehydrateQuery`. |
+| Key | `asset-series` + provider + canonical symbol/pair + source/quote + frequency + requested range; never Portfolio id. |
+| Daily refresh | Refetch the latest one-month tail, date-merge it into the long-range query, and keep the old series on failure. |
+| Freshness | Set daily `staleTime` to permit daily reconciliation; set `gcTime >= maxAge`; choose `maxAge` for offline continuity. |
+| Failure | Preserve last successful data on refetch failure and expose stale/error metadata; discard only invalid/expired persisted snapshots. |
+
+## Remaining implementation decisions
+
+- Canonical symbol and FX-pair normalization, including provider and exchange identity.
+- The exact UTC/business-date rule and whether the newest daily point is allowed before the provider's daily candle is final.
+- The desired offline continuity window, which determines `maxAge` and the matching `gcTime`.
+- Whether a long-range query uses one bounded response or pages/chunks the series; large payloads should be measured before choosing one giant query.
+- A provider retry policy, because the current repository-wide `retry: false` is not enough for reliable daily-tail maintenance.

--- a/docs/research/timescaledb-production-local-ci-parity.md
+++ b/docs/research/timescaledb-production-local-ci-parity.md
@@ -1,0 +1,161 @@
+# Findings: TimescaleDB production, local, and CI parity
+
+Research date: 2026-08-05
+
+## Context
+
+- Ticket: [Research: Verify TimescaleDB local and CI parity](https://github.com/dcapal/dcapal/issues/757)
+- Wayfinder map: [Portfolio management hub and allocation workflows](https://github.com/dcapal/dcapal/issues/742)
+
+This is a research finding, not a product-code change. It uses the current
+repository source and first-party TimescaleDB, SQLx, and Supabase documentation.
+Redis is explicitly outside this epic.
+
+## Executive findings
+
+1. **The repository already has a suitable local TimescaleDB service.** The base
+   Compose file uses `timescale/timescaledb-ha:pg17`, exposes PostgreSQL only to
+   the Compose network, supplies `POSTGRES_PASSWORD`, and waits for both
+   `pg_isready` and `SELECT 1`. This is the same official image family and
+   PostgreSQL major version recommended by Timescale's Docker installation guide,
+   which documents `timescale/timescaledb-ha:pg17` and says the image pre-creates
+   TimescaleDB in the default database and adds it to new databases. [Repository
+   Compose service](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/docker-compose.yml#L20-L37)
+   and [Timescale Docker installation](https://docs.timescale.com/self-hosted/latest/install/installation-docker/)
+
+2. **The production contract must be explicit about the extension.** A
+   Timescale image makes the extension available, but a database migration still
+   needs to verify or create it in the target database with
+   `CREATE EXTENSION IF NOT EXISTS timescaledb`. Timescale describes TimescaleDB
+   as a PostgreSQL extension and gives this command for self-hosted instances.
+   Production is therefore Timescale-compatible only when its PostgreSQL target
+   has the extension installed and enabled; a plain Supabase PostgreSQL target
+   is not equivalent merely because local Compose is Timescale-based. [Timescale
+   self-hosted installation](https://docs.timescale.com/self-hosted/latest/install/)
+   and [Timescale troubleshooting: create the extension](https://docs.timescale.com/self-hosted/latest/troubleshooting/)
+
+3. **Hypertables fit time-series observations, not the current portfolio tables.**
+   Timescale defines a hypertable as a PostgreSQL table partitioned by time. A
+   candidate observation table should have a non-null `timestamptz` partition
+   column, a stable series identity, and query indexes such as
+   `(series_id, observed_at)`. Any primary key or unique index on a hypertable
+   must include every partitioning column, normally the time column. [Timescale
+   `create_hypertable` guidance](https://docs.timescale.com/api/latest/hypertable/create_hypertable/)
+   and [hypertable unique-index rules](https://docs.timescale.com/use-timescale/latest/hypertables/hypertables-and-unique-indexes/)
+
+4. **Keep application job state in ordinary application tables.** Timescale's
+   `timescaledb_information.jobs` and `job_history` describe the extension's
+   internal policy and background-worker jobs, including schedule, retries,
+   next start, success, and error fields. They are useful for observing retention
+   or aggregate policies, but they are not a substitute for a DcaPal fetch-job
+   table with an application idempotency key, ownership/claim state, provider
+   identity, requested range, and durable error details. [Timescale jobs view](https://docs.timescale.com/api/latest/informational-views/jobs/)
+   and [Timescale job history view](https://docs.timescale.com/api/latest/informational-views/job_history/)
+
+5. **SQLx can run the same migrations and fixtures against TimescaleDB.** The
+   repository embeds migrations with `sqlx::migrate!("../migrations")`; the
+   migration runner connects using `DATABASE_URL` and runs the embedded
+   `Migrator`. SQLx documents that `migrate!` embeds migrations in the binary and
+   that migration files are resolved relative to the Cargo project root. The
+   Timescale-specific risk is therefore SQL, not the Rust pool boundary: the
+   migration must be tested against a database where the extension is available,
+   and any hypertable unique constraint must include its time partition column.
+   [Repository migration crate](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/migration/src/lib.rs#L1-L2),
+   [repository migration runner](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/migration/src/main.rs#L7-L18),
+   and [SQLx `migrate!` documentation](https://docs.rs/sqlx/0.9.0/sqlx/macro.migrate.html)
+
+6. **The current SQLx compatibility boundary is valuable and should remain.**
+   The repository has a migration-compatibility test that starts from a fixture
+   representing the existing SeaORM schema, runs the SQLx migrator, checks
+   `_sqlx_migrations`, preserves `seaql_migrations`, and verifies the numeric
+   column type. A Timescale migration should add the same kind of adoption test:
+   verify extension availability, hypertable status, partition column, indexes,
+   and application metadata without assuming an empty database. [Migration
+   compatibility test](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/tests/migration_compatibility.rs#L1-L30)
+   and [migration ADR](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/docs/adr/0001-sqlx-persistence-and-migrations.md#decision)
+
+7. **Ordinary CI should use the Timescale Compose database for backend tests.**
+   The current `backend-test` job installs the Supabase CLI, starts Supabase,
+   and runs `make test-backend`; the Makefile defaults `DATABASE_URL` to
+   Supabase's `127.0.0.1:54322` endpoint. This makes ordinary SQLx tests depend
+   on the wrong database implementation for a Timescale contract. The ordinary
+   job should instead start only the Timescale `db` service with the local Compose
+   port mapping, wait for its health check, set `DATABASE_URL` to that mapped
+   endpoint, and run the same migration and SQLx test commands. [Current backend
+   CI job](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/.github/workflows/build-test.yml#L54-L92),
+   [Makefile database defaults and tests](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/Makefile#L1-L7),
+   [Makefile Compose targets](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/Makefile#L99-L117),
+   and [SQLx test attribute documentation](https://docs.rs/sqlx/latest/sqlx/attr.test.html)
+
+8. **Supabase should be isolated to a smoke-test boundary.** The existing
+   `backend-smoke-test` already starts Supabase separately, configures the
+   application to use the Compose `db` service, and starts the Timescale/Redis
+   application stack with `docker compose ... up --wait`. That job is the right
+   place to retain Supabase checks that exercise Supabase-specific auth or local
+   service wiring. It should not be the database oracle for ordinary repository
+   migrations or SQLx tests. Supabase's own documentation describes the CLI as a
+   local configuration and development environment; it does not make a Supabase
+   database and a self-hosted Timescale image the same production contract.
+   [Current backend smoke job](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/.github/workflows/build-test.yml#L330-L481)
+   and [Supabase local configuration documentation](https://supabase.com/docs/guides/local-development/managing-config)
+
+9. **Redis is a separate runtime dependency and should not be changed here.**
+   The Compose file defines Redis with its own image and health check, and the
+   backend constructs Redis-backed market, statistics, imported, and miscellaneous
+   repositories at application startup. The current database integration tests,
+   however, use only `PgPool` and SQLx fixtures. The Timescale parity epic can
+   therefore exclude Redis while keeping the existing Redis service in the smoke
+   stack and leaving Redis-specific behavior for a separate issue. [Redis Compose
+   service](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/docker-compose.yml#L2-L18),
+   [backend runtime wiring](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/src/lib.rs#L125-L145),
+   and [current PostgreSQL-only integration tests](https://github.com/dcapal/dcapal/blob/f652260de11204971f95b6235ffc40cf812911a1/dcapal-backend/tests/portfolio_repository.rs#L58-L129)
+
+## Recommended boundary for the implementation ticket
+
+The next implementation should make the database contract explicit in one
+forward SQLx migration:
+
+- Use `CREATE EXTENSION IF NOT EXISTS timescaledb` only if production ownership
+  and permissions allow it; otherwise fail clearly during deployment rather than
+  silently falling back to plain PostgreSQL.
+- Create the observation table with a non-null `timestamptz` partition column and
+  an application-level series key. Choose the unique key with the time column
+  included, for example `(series_id, observed_at)`.
+- Keep provider metadata, fetch timestamps, and application job state in ordinary
+  columns/tables. Inspect Timescale policy jobs through informational views, but
+  do not use those views as the application's job ledger.
+- Add a compatibility test for the existing schema and a Timescale-specific test
+  that asserts `pg_extension`, hypertable metadata, indexes, and idempotent
+  re-running of the migration.
+- Keep repository tests on `#[sqlx::test(migrations = "./migrations", fixtures(...))]`.
+  SQLx applies migrations and fixtures in isolated test databases; fixture order
+  must continue to satisfy foreign keys. [SQLx test and fixture guidance](https://docs.rs/sqlx/latest/sqlx/attr.test.html)
+- Change ordinary backend CI to start the Timescale Compose `db` service and
+  point SQLx at it. Keep Supabase startup and any Supabase-specific checks in an
+  explicitly named smoke job. Keep Redis out of the migration and ordinary SQLx
+  test setup.
+
+## Operational acceptance criteria
+
+The implementation is ready when a clean checkout can demonstrate all of the
+following:
+
+1. The Compose database reports healthy only after PostgreSQL accepts both
+   readiness and a real query, and `SELECT extname, extversion FROM pg_extension`
+   reports `timescaledb`.
+2. The migration runner succeeds against the Timescale Compose database and a
+   second run reports no pending migration.
+3. The migration-compatibility test preserves the existing SeaORM metadata and
+   the new Timescale test proves the intended hypertable and index metadata.
+4. `cargo test -p dcapal-backend -p migration -- --nocapture` passes with
+   `DATABASE_URL` pointing at TimescaleDB and without starting Supabase or Redis.
+5. The named Supabase smoke job still starts its own Supabase services and the
+   existing Compose application stack, while failure logs identify which service
+   failed.
+
+The production decision that remains open is not whether SQLx can talk to
+TimescaleDB; it can. The decision is whether the production PostgreSQL service
+will be explicitly pinned and operated as a TimescaleDB-capable target. If that
+cannot be guaranteed, use ordinary PostgreSQL partitioning for the first
+production schema and treat TimescaleDB as an optional local/CI profile rather
+than claiming production/local parity.


### PR DESCRIPTION
## Summary

- Add the four AFK research findings for Yahoo/Kraken market data, TimescaleDB parity, TanStack Query persistence, and Supabase auth mocking.
- Record the aligned historical-series and market-data vocabulary updates in the backend and frontend context files.
- Collect the findings for the follow-up Wayfinder decisions under the portfolio-management map.

## Research conclusions

- Yahoo Finance is authoritative for non-crypto market data and FX conversion series; Kraken is the crypto source; CryptoWatch is removed.
- TimescaleDB is the database contract for production, local development, and ordinary CI. Supabase remains isolated to smoke coverage.
- TanStack Query persistence with an IndexedDB persister is the smallest browser-cache direction; Zustand remains client state.
- No qualifying small off-the-shelf Supabase auth double was found. A narrow test-only in-repository adapter is recommended.

## Validation

- git diff --cached --check
- git show --check HEAD
- Documentation-only change; no runtime tests were required.

The unrelated PR-649 MIGRATION.md and agent_docs/ artifacts remain outside this PR.